### PR TITLE
argh 0.28.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "argh" %}
-{% set version = "0.26.2" %}
+{% set version = "0.28.1" %}
 {% set hash_type = "sha256" %}
-{% set hash = "e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65" %}
+{% set hash = "b2093086f0e809a3ecc24b64a2145309ee8f56d034936cd59e57c558a357329d" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index c50f1d7..f7daf85 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "argh" %}
-{% set version = "0.26.2" %}
+{% set version = "0.28.1" %}
 {% set hash_type = "sha256" %}
-{% set hash = "e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65" %}
+{% set hash = "b2093086f0e809a3ecc24b64a2145309ee8f56d034936cd59e57c558a357329d" %}
 
 package:
   name: {{ name }}

```

**Jira ticket:** []() (-)

**The upstream data:**

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: medium | Category: anaconda | subcategory:  | pkg_type: python
 * Outdated platforms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.28.1
 * Release on PyPi:
    * version: 0.28.1
    * date: 2023-02-16T13:31:01
* [PyPi history](https://pypi.org/project/argh/#history)
 * Popularity: 
    * 3 months downloads: 63932.0
    * All time:  1182462 downloads -  argh  0.27.2  The Natural CLI.  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the 'build_number' is correct
3. - [x] has 'setuptools'
6. - [ ] Verify if the package needs 'wheel'
    
8. - [ ] NO 'pip' in test
    
9. - [ ] Verify the test section
10. - [ ] Verify if the package is 'architecture specific'
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
13.  - [ ] license_file doesn't exist!

15. - [ ] License family is NOT present
    
16. - [x] License: LGPL
    - [x] License is 'spdx' compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier        |
|:------------------|
| LGPL-2.0-only     |
| LGPL-2.0-or-later |
| LGPL-2.1-only     |
| LGPL-2.1-or-later |
| LGPL-3.0-only     |
| LGPL-3.0-or-later |
| LGPLLR            |
</details>

**Other:**

<details>
Checking 'argh' recipe...
~/OneDrive - SoftServe, Inc/src/aggregate/argh-feedstock/recipe ~/OneDrive - SoftServe, Inc/src/finder
--- Build Requirements ---
>> Empty Host Section <<
--- Host Requirements ---
setuptools: main
--- Run Requirements ---
[91m>>>>> argparse >=1.1 Only on conda-forge[0m
~/OneDrive - SoftServe, Inc/src/finder

</details>

<details>

https://repo.anaconda.com/pkgs/main/noarch
https://repo.anaconda.com/pkgs/main/linux-64
argh-0.26.2-py36_0.tar.bz2
argh-0.26.2-py37_0.tar.bz2
argh-0.26.2-py38_0.tar.bz2
argh-0.26.2-py310h06a4308_0.tar.bz2
argh-0.26.2-py39h06a4308_0.tar.bz2
argh-0.26.2-py27_0.tar.bz2
https://repo.anaconda.com/pkgs/main/linux-ppc64le
argh-0.26.2-py36_0.tar.bz2
argh-0.26.2-py37_0.tar.bz2
argh-0.26.2-py38_0.tar.bz2
argh-0.26.2-py310h6ffa863_0.tar.bz2
argh-0.26.2-py39h6ffa863_0.tar.bz2
argh-0.26.2-py27_0.tar.bz2
https://repo.anaconda.com/pkgs/main/linux-aarch64/
argh-0.26.2-py38hd43f75c_0.tar.bz2
argh-0.26.2-py310hd43f75c_0.tar.bz2
argh-0.26.2-py37hd43f75c_0.tar.bz2
argh-0.26.2-py39hd43f75c_0.tar.bz2
https://repo.anaconda.com/pkgs/main/linux-s390x/
https://repo.anaconda.com/pkgs/main/osx-64
argh-0.26.2-py36_0.tar.bz2
argh-0.26.2-py37_0.tar.bz2
argh-0.26.2-py38_0.tar.bz2
argh-0.26.2-py39hecd8cb5_0.tar.bz2
argh-0.26.2-py27_0.tar.bz2
argh-0.26.2-py310hecd8cb5_0.tar.bz2
https://repo.anaconda.com/pkgs/main/osx-arm64/
argh-0.26.2-py39hca03da5_0.tar.bz2
argh-0.26.2-py38hca03da5_0.tar.bz2
argh-0.26.2-py310hca03da5_0.tar.bz2
https://repo.anaconda.com/pkgs/main/win-64
argh-0.26.2-py36_0.tar.bz2
argh-0.26.2-py37_0.tar.bz2
argh-0.26.2-py38_0.tar.bz2
argh-0.26.2-py39haa95532_0.tar.bz2
argh-0.26.2-py310haa95532_0.tar.bz2
argh-0.26.2-py27_0.tar.bz2

</details>

<details>

                 name  version                spec
0   _anaconda_depends  2021.11                argh
1   _anaconda_depends  2020.07                argh
2   _anaconda_depends  2020.02                argh
3            anaconda  2021.11  argh 0.26.2 py37_0
4            anaconda  2021.05  argh 0.26.2 py38_0
5            anaconda  2021.04  argh 0.26.2 py37_0
6            anaconda  2020.11  argh 0.26.2 py37_0
7            anaconda  2020.07  argh 0.26.2 py37_0
8            anaconda  2020.02  argh 0.26.2 py36_0
9            watchdog    2.1.3       argh >=0.24.1
10           watchdog    2.1.1       argh >=0.24.1
11           watchdog    1.0.2       argh >=0.24.1
12           watchdog   0.10.4       argh >=0.24.1
13           watchdog   0.10.3       argh >=0.24.1
14           watchdog   0.10.2       argh >=0.24.1
15           watchdog   0.10.1       argh >=0.24.1
16           watchdog    0.9.0       argh >=0.24.1

</details>

</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/argh-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/argh-feedstock/tree/0.28.1)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/argh)
* [Diff between upstream and feature branch](https://github.com/conda-forge/argh-feedstock/compare/main...AnacondaRecipes:0.28.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/argh-feedstock/compare/master...AnacondaRecipes:0.28.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/argh-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.28.1 git@github.com:AnacondaRecipes/argh-feedstock.git
```
